### PR TITLE
Fix proxy

### DIFF
--- a/deployment/templates/deploymentconfig.yaml
+++ b/deployment/templates/deploymentconfig.yaml
@@ -45,6 +45,9 @@ spec:
           {{- else }}
           mountPath: /opt/app-root/src/config
           {{- end }}
+        - name: httpd-volume
+          mountPath: /etc/httpd/conf.d/fe-httpd.conf
+          subPath: fe-httpd.conf
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -54,6 +57,9 @@ spec:
       - name: config-volume
         configMap:
           name: frontend-config
+      - name: httpd-volume
+        configMap:
+          name: httpd-config
   triggers: 
   - type: ConfigChange
   - type: ImageChange

--- a/deployment/templates/fe-configmap.yaml
+++ b/deployment/templates/fe-configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.development }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,4 +7,3 @@ data:
     {
       "baseUrl": "{{ .Values.baseUrl }}",
     }
-{{- end }}

--- a/deployment/templates/httpd-configmap.yaml
+++ b/deployment/templates/httpd-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  fe-httpd.conf: |
+    {{ .Values.httpdConfig -}}
+kind: ConfigMap
+metadata:
+  name: httpd-config
+
+

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -4,3 +4,6 @@ servicePort: 8080
 
 imageName: "quay.io/rht-labs/fee-fe"
 imageTag: "latest" # This is intended to be overridden by the parent Helm chart.
+
+httpdConfig: |
+    FallbackResource / 

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "vue-router": "^3.1.6",
     "vuetify": "^2.2.11",
     "vuex": "^3.1.3",
-    "vuex-persistedstate": "^3.0.1",
-    "@vue/cli-service": "~4.3.0"
+    "vuex-persistedstate": "^3.0.1"
   },
   "devDependencies": {
+    "@vue/cli-service": "~4.3.0",
     "@vue/cli-plugin-babel": "~4.3.0",
     "@vue/cli-plugin-e2e-nightwatch": "~4.3.0",
     "@vue/cli-plugin-eslint": "~4.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "vue-cli-service serve --open",
     "serve": "vue-cli-service serve --open",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
@@ -27,7 +26,6 @@
     "vuex-persistedstate": "^3.0.1"
   },
   "devDependencies": {
-    "@vue/cli-service": "~4.3.0",
     "@vue/cli-plugin-babel": "~4.3.0",
     "@vue/cli-plugin-e2e-nightwatch": "~4.3.0",
     "@vue/cli-plugin-eslint": "~4.3.0",
@@ -35,6 +33,7 @@
     "@vue/cli-plugin-router": "~4.3.0",
     "@vue/cli-plugin-unit-jest": "~4.3.0",
     "@vue/cli-plugin-vuex": "~4.3.0",
+    "@vue/cli-service": "~4.3.0",
     "@vue/eslint-config-airbnb": "^5.0.2",
     "@vue/test-utils": "1.0.0-beta.31",
     "babel-eslint": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "vue-router": "^3.1.6",
     "vuetify": "^2.2.11",
     "vuex": "^3.1.3",
-    "vuex-persistedstate": "^3.0.1"
+    "vuex-persistedstate": "^3.0.1",
+    "@vue/cli-service": "~4.3.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.3.0",
@@ -34,7 +35,6 @@
     "@vue/cli-plugin-router": "~4.3.0",
     "@vue/cli-plugin-unit-jest": "~4.3.0",
     "@vue/cli-plugin-vuex": "~4.3.0",
-    "@vue/cli-service": "~4.3.0",
     "@vue/eslint-config-airbnb": "^5.0.2",
     "@vue/test-utils": "1.0.0-beta.31",
     "babel-eslint": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "start": "vue-cli-service serve --open",
     "serve": "vue-cli-service serve --open",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",


### PR DESCRIPTION
This adds a configmap that you can modify to add additional httpd configurations. Currently it just sets the `FallbackResource`, but other settings could be added there as well if necessary.

I also made a change to the `frontend-config` ConfigMap as it was only being deployed as part of the `development` chart, but this caused issues when deploying the "real" chart as it was looking for this configmap there as well. 

cc/ @philipdouble 